### PR TITLE
Add controls, instructions, etc. to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # The Everything Building
 
-Ludum Dare 34 Jam Game - ranked #2 Overall, #1 Fun.
+[Ludum Dare 34 Jam Game](http://ludumdare.com/compo/ludum-dare-34/?action=preview&uid=52430) - ranked #2 Overall, #1 Fun - ### [<kbd>PLAY IT NOW</kbd>](http://oletus.github.io/elevator/)
 
-**By:**
+![cropped gameplay](http://i.imgur.com/RGF0W6d.gif)
+
+### Elevator Operator’s Manual 
+
+We are delighted to welcome you to the team as our newest elevator operator. You will be expected to serve the vertical mobility needs of some very busy and important people (and animals). We expect you to convey them to their desired floor with speed, efficiency and a smile. 
+
+* :arrow_up: To go up - press up
+* :arrow_down: To go down - press down
+
+If successful, you will be rewarded with generous tips. But keep the line moving, or it’s all over for you. 
+
+Now get to work! 
+
+Sincerely,<br>
+The Management 
+
+### Game Rules
+
+* Take numbered customers to their respective destination floor to receive coins 
+* Customers appear on floors: avoid overcrowding a floor by transporting customers before they fill any floor entirely 
+* Combo: More people arriving on the same floor at the same time means more coins 
+* Size: The customers come in three sizes (small, medium, large) and the elevator can hold three small, one small and one medium or a single large customer at a time. 
+* Many customers have their own properties and behaviours: learn and master their quirkiness to score as much as you can before any floors overcrowd! 
+
+### Credits
 * [Olli Etuaho](https://twitter.com/oletus) - code, graphics, design
 * [Kimmo Keskinen](https://twitter.com/kavrielh) - code, design
 * Sakari Leppä - graphics, design
@@ -10,5 +34,3 @@ Ludum Dare 34 Jam Game - ranked #2 Overall, #1 Fun.
 * Anastasia Diatlova - design
 
 Using [gameutils.js](https://github.com/oletus/gameutils.js/)
-
-### [Play now](http://oletus.github.io/elevator/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Everything Building
 
-[Ludum Dare 34 Jam Game](http://ludumdare.com/compo/ludum-dare-34/?action=preview&uid=52430) - ranked #2 Overall, #1 Fun - ### [<kbd>PLAY IT NOW</kbd>](http://oletus.github.io/elevator/)
-
 ![cropped gameplay](http://i.imgur.com/RGF0W6d.gif)
+
+[Ludum Dare 34 Jam Game](http://ludumdare.com/compo/ludum-dare-34/?action=preview&uid=52430) - ranked #2 Overall, #1 Fun - [<kbd>PLAY IT NOW</kbd>](http://oletus.github.io/elevator/)
 
 ### Elevator Operator’s Manual 
 


### PR DESCRIPTION
People finding this (awesome) game via the GitHub page won't find the controls, instructions, etc. This adds some copy taken verbatim from the [jam page](http://ludumdare.com/compo/ludum-dare-34/ to the `README`?action=preview&uid=52430) :metal:

Cheers,
  Lee :beers:
